### PR TITLE
Rework gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,14 @@ Or install it yourself as:
 advance_rules = ["start now", "advance 2 days", "advance 4 days", "advance 1 week"]
 
 window_rules = {
-       days:       "Monday:Tuesday:Wednesday:Thursday",
-       start_time: "9:00",
-       end_time:   "11:00",
-     }
+  working_hours: {
+    mon: {"09:00" => "11:00"},
+    tue: {"09:00" => "11:00"},
+    wed: {"09:00" => "11:00"},
+    thu: {"09:00" => "11:00"}
+  },
+  time_zone: 'Eastern Time (US & Canada)'
+}
 
 AdvanceAFewDays.create_days(window_rules, advance_rules, Time.now, 'Eastern Time (US & Canada)')
 ```

--- a/advance_a_few_days.gemspec
+++ b/advance_a_few_days.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "working_hours"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/advance_a_few_days.rb
+++ b/lib/advance_a_few_days.rb
@@ -1,171 +1,68 @@
 require "advance_a_few_days/version"
-require 'active_support'
-require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/numeric/time'
-require 'active_support/core_ext/time/zones'
+require "working_hours"
 
 module AdvanceAFewDays
-
-  def self.create_days(window_rules, start_rules, start_datetime = Time.now, time_zone_name = 'Eastern Time (US & Canada)')
-    schedule = create_days_on_earliest_send_time(window_rules, start_rules, start_datetime)
-
-    randomized_times = randomize_times(window_rules, schedule)
-
-    moved_times_to_time_zone = move_times_to_time_zone(randomized_times, time_zone_name)
-  end
-
-  def self.move_times_to_time_zone(schedule, time_zone_name)
-    offset = Time.now.in_time_zone(time_zone_name).utc_offset
-    schedule.map do |date_time|
-      date_time - (offset.to_f / (60 * 60 * 24))
+  class << self
+    def create_days(window_rules, start_rules, start_datetime)
+      schedule = create_days_on_earliest_send_time(window_rules, start_rules, start_datetime)
+      randomize_times(window_rules, schedule)
     end
-  end
 
-  def self.randomize_times(window_rules, schedule)
-    schedule.map do |datetime|
-      new_randomized_time_in_range = new_randomized_time_in_range(window_rules)
-      combine_date_and_time(datetime.to_date, new_randomized_time_in_range)
-    end
-  end
-
-  def self.new_randomized_time_in_range(window_rules)
-    early_time, late_time = extra_time_range_from_rules(window_rules)
-
-    range = late_time - early_time
-
-    early_time + rand * range.to_f
-  end
-  
-  def self.create_days_on_earliest_send_time(window_rules, start_rules, start_datetime)
-
-    start_rules.reduce([]) do |acc, rule| 
-      value = if acc == []
-        find_next_occurence(window_rules, rule, start_datetime)
-      else
-        find_next_occurence(window_rules, rule, acc.last)
+    def randomize_times(config, schedule)
+      WorkingHours::Config.with_config(config) do
+        schedule.map do |datetime|
+          new_randomized_time_in_range(datetime)
+        end
       end
-
-      acc << (value)
     end
-  end
 
-  def self.find_next_occurence(window_rules, rule, start_datetime)
-    if rule =~ /start/
-      handle_start_rule(window_rules, start_datetime)
-    elsif rule =~ /advance \d+ day/i
-      handle_advance_days(window_rules, rule, start_datetime)
-    elsif rule =~ /advance \d+ week/i
-      handle_advance_weeks(window_rules, rule, start_datetime)
-    else
-      raise "expected rule #{rule} to be parsed but wasn't"
+    def new_randomized_time_in_range(datetime)
+      early_time = datetime
+      late_time  = WorkingHours.advance_to_closing_time(datetime)
+      range      = late_time - early_time
+
+      early_time + rand * range.to_f
     end
-  end
 
-  def self.handle_advance_weeks(window_rules, rule, start_datetime)
-    day_number = rule.scan(/\d+/).first
-    start_datetime = start_datetime + (day_number.to_i * 7)
-    handle_start_rule(window_rules, start_datetime)    
-  end
+    def create_days_on_earliest_send_time(window_rules, start_rules, start_datetime)
+      WorkingHours::Config.with_config(window_rules) do
+        start_rules.reduce([]) do |acc, rule|
+          value = if acc == []
+            find_next_occurence(rule, start_datetime)
+          else
+            find_next_occurence(rule, acc.last)
+          end
 
-  def self.handle_advance_days(window_rules, rule, start_datetime)
-    day_number = rule.scan(/\d+/).first
-    start_datetime = start_datetime + day_number.to_i
-    handle_start_rule(window_rules, start_datetime)    
-  end
-
-  def self.handle_start_rule(window_rules, start_datetime)
-    if in_window?(window_rules, start_datetime)
-      start_datetime
-    else
-      next_datetime_in_window(window_rules, start_datetime)
-    end
-  end
-
-  def self.in_window?(window_rules, start_datetime)
-    on_a_good_day?(window_rules, start_datetime.to_date) && at_a_good_time?(window_rules, start_datetime)
-  end
-
-  def self.next_datetime_in_window(window_rules, start_datetime)
-    next_good_day = next_date_in_window(window_rules, start_datetime.to_date)
-    next_good_time = next_time_in_window(window_rules, start_datetime)
-    combine_date_and_time(next_good_day, next_good_time)
-  end
-
-  def self.combine_date_and_time(date, time)
-    string = date.strftime("%F") + " " + time.strftime("%H:%M")
-    DateTime.strptime(string, "%F %H:%M")
-  end
-
-  def self.next_time_in_window(window_rules, datetime)
-    early_time, late_time = extra_time_range_from_rules(window_rules)
-
-    early_time
-  end
-
-  def self.next_date_in_window(window_rules, date)
-    try_date = date
-    next_good_day = nil
-    while(next_good_day == nil) do
-      if on_a_good_day?(window_rules, try_date)
-        next_good_day = try_date
-      else
-        try_date = try_date + 1
+          acc << (value)
+        end
       end
-    end  
+    end
 
-    next_good_day
-  end
+    def find_next_occurence(rule, start_datetime)
+      start_datetime = get_start_time(rule, start_datetime)
+      handle_start_rule(start_datetime)
+    end
 
-  
+    def get_start_time(rule, start_datetime)
+      numeral = rule.scan(/\d+/).first
 
-  def self.extract_date(start_datetime)
-    start_datetime.to_date
-  end
+      if rule =~ /start/
+        start_datetime
+      elsif rule =~ /\d+ day/i
+        start_datetime + numeral.to_i.days
+      elsif rule =~ /\d+ week/i
+        start_datetime + (numeral.to_i * 7).days
+      else
+        raise "expected rule #{rule} to be parsed but wasn't"
+      end
+    end
 
-  def self.on_a_good_day?(window_rules, start_datetime)
-    parse_days_of_week(window_rules).include?(start_datetime.wday)
-  end
-
-  def self.day_name_to_number(day_name)
-    case day_name
-    when /sunday/i
-      0
-    when /monday/i
-      1
-    when /tuesday/i
-      2
-    when /wednesday/i
-      3
-    when /thursday/i
-      4
-    when /friday/i
-      5
-    when /satursday/i
-      6
-    else
-      raise "expected `#{day_name}` to be like Sunday, Monday... but wasn't"
+    def handle_start_rule(start_datetime)
+      if WorkingHours.in_working_hours?(start_datetime)
+        start_datetime
+      else
+        WorkingHours.advance_to_working_time(start_datetime)
+      end
     end
   end
-
-  def self.parse_days_of_week(window_rules)
-    window_rules[:days]
-      .split(":")
-      .map{|day_name| day_name_to_number(day_name)}
-  end
-
-  def self.at_a_good_time?(window_rules, start_datetime)
-    early_time, late_time = extra_time_range_from_rules(window_rules)
-
-    (extract_time(start_datetime) >= early_time) && (extract_time(start_datetime) <= late_time)
-  end
-
-  def self.extract_time(datetime)
-    hours_and_minutes = datetime.strftime('%H:%M')
-    DateTime.strptime(hours_and_minutes, '%H:%M')
-  end
-
-  def self.extra_time_range_from_rules(window_rules)
-    [DateTime.strptime(window_rules[:start_time], '%H:%M'), DateTime.strptime(window_rules[:end_time], '%H:%M')]
-  end
-
 end

--- a/spec/advance_two_days_spec.rb
+++ b/spec/advance_two_days_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe AdvanceAFewDays do
-
   describe "create_days" do
     let(:rule1) { "start now" }
     let(:rule2) { "advance 2 days" }
@@ -9,21 +8,18 @@ describe AdvanceAFewDays do
     let(:rule4) { "advance 1 week" }
 
     let(:advance_rules) { [rule1, rule2, rule3, rule4]}
-
-    let(:time_zone_name) { 'Eastern Time (US & Canada)' }
-
+    let(:start_datetime) { Time.parse('2016-02-20 09:00:00').in_time_zone('Eastern Time (US & Canada)') }
     let(:window_rules) do
       {
-        days:       "Monday:Tuesday:Wednesday:Thursday",
-        start_time: "9:00",
-        end_time:   "11:00",
+        working_hours: {
+          mon: {"09:00" => "11:00"},
+          tue: {"09:00" => "11:00"},
+          wed: {"09:00" => "11:00"},
+          thu: {"09:00" => "11:00"}
+        },
+        time_zone: 'Eastern Time (US & Canada)'
       }
     end
-
-    
-    let(:start_datetime) { DateTime.strptime('2016-02-20 09:00:00', '%Y-%m-%d %H:%M:%S') }
-
-    let(:time_zone_name) { 'Eastern Time (US & Canada)' }
 
     subject { AdvanceAFewDays.create_days(window_rules, advance_rules, start_datetime) }
 
@@ -33,14 +29,9 @@ describe AdvanceAFewDays do
       date3 = Date.parse('2016-02-29')
       date4 = Date.parse('2016-03-07')
 
-      #
-      # more of a basic than exact check
-      #
-
       expect(subject.map(&:to_date)).to eq [date1, date2, date3, date4]
     end
   end
-
 
   describe "create_days_on_earliest_send_time" do
     let(:rule1) { "start now" }
@@ -49,24 +40,22 @@ describe AdvanceAFewDays do
     let(:rule4) { "advance 1 week" }
 
     let(:advance_rules) { [rule1, rule2, rule3, rule4]}
-
+    let(:start_datetime) { Time.parse('2016-02-20 09:00:00 +0000') }
     let(:window_rules) do
       {
-        days:       "Monday:Tuesday:Wednesday:Thursday",
-        start_time: "9:00",
-        end_time:   "11:00",
+        working_hours: {
+          mon: {"09:00" => "11:00"},
+          tue: {"09:00" => "11:00"},
+          wed: {"09:00" => "11:00"},
+          thu: {"09:00" => "11:00"}
+        },
+        time_zone: 'UTC'
       }
     end
 
-    
-
-    let(:start_datetime) { DateTime.strptime('2016-02-20 09:00:00', '%Y-%m-%d %H:%M:%S') }
-
-    let(:time_zone_name) { 'Eastern Time (US & Canada)' }
-
     subject { AdvanceAFewDays.create_days_on_earliest_send_time(window_rules, advance_rules, start_datetime) }
 
-    it 'should return the future advance times', focus: true do
+    it 'should return the future advance times' do
       date1 = DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S')
       date2 = DateTime.strptime('2016-02-24 09:00:00', '%Y-%m-%d %H:%M:%S')
       date3 = DateTime.strptime('2016-02-29 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -77,7 +66,6 @@ describe AdvanceAFewDays do
 
     describe "randomize_times" do
       it 'should randomize the times within the window_rules range' do
-
         date1 = DateTime.strptime('2016-02-22 10:00:00', '%Y-%m-%d %H:%M:%S')
         date2 = DateTime.strptime('2016-02-24 10:00:00', '%Y-%m-%d %H:%M:%S')
         date3 = DateTime.strptime('2016-02-29 10:00:00', '%Y-%m-%d %H:%M:%S')
@@ -89,31 +77,11 @@ describe AdvanceAFewDays do
         expect(randomized_send_times_schedule[1]).to be_within(1.hours).of date2
         expect(randomized_send_times_schedule[2]).to be_within(1.hours).of date3
         expect(randomized_send_times_schedule[3]).to be_within(1.hours).of date4
-
-      end
-
-      describe "move times to time zone" do
-        it 'should move the times to time zone' do
-
-          date1 = DateTime.strptime('2016-02-22 14:00:00', '%Y-%m-%d %H:%M:%S')
-          date2 = DateTime.strptime('2016-02-24 14:00:00', '%Y-%m-%d %H:%M:%S')
-          date3 = DateTime.strptime('2016-02-29 14:00:00', '%Y-%m-%d %H:%M:%S')
-          date4 = DateTime.strptime('2016-03-07 14:00:00', '%Y-%m-%d %H:%M:%S')
-
-          in_time_zone = AdvanceAFewDays.move_times_to_time_zone(subject, time_zone_name)
-
-          expect(in_time_zone[0]).to eq date1
-          expect(in_time_zone[1]).to eq date2
-          expect(in_time_zone[2]).to eq date3
-          expect(in_time_zone[3]).to eq date4
-
-        end
       end
     end
 
     context "starting Sunday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-21 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-21 09:00:00').in_time_zone('Eastern Time (US & Canada)') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -126,8 +94,7 @@ describe AdvanceAFewDays do
     end
 
     context "starting Monday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-22 09:00:00 +0000') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -140,8 +107,7 @@ describe AdvanceAFewDays do
     end
 
     context "starting Tuesday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-23 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-23 09:00:00 +0000') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-23 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -154,8 +120,7 @@ describe AdvanceAFewDays do
     end
 
     context "starting Wednesday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-24 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-24 09:00:00 +0000') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-24 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -168,8 +133,7 @@ describe AdvanceAFewDays do
     end
 
     context "starting Thursday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-25 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-25 09:00:00 +0000') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-25 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -182,8 +146,7 @@ describe AdvanceAFewDays do
     end
 
     context "starting Friday" do
-
-      let(:start_datetime) { DateTime.strptime('2016-02-26 09:00:00', '%Y-%m-%d %H:%M:%S') }
+      let(:start_datetime) { Time.parse('2016-02-26 09:00:00 +0000') }
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-29 09:00:00', '%Y-%m-%d %H:%M:%S')
@@ -196,15 +159,15 @@ describe AdvanceAFewDays do
     end
 
     context "Wednesday-Thursday 10am-11am" do
-
       let(:window_rules) do
         {
-          days:       "Wednesday:Thursday",
-          start_time: "10:00",
-          end_time:   "11:00",
+          working_hours: {
+            wed: {"10:00" => "11:00"},
+            thu: {"10:00" => "11:00"}
+          },
+          time_zone: 'UTC'
         }
       end
-
 
       it 'should return the future advance times' do
         date1 = DateTime.strptime('2016-02-24 10:00:00', '%Y-%m-%d %H:%M:%S')
@@ -218,12 +181,14 @@ describe AdvanceAFewDays do
     end
 
     context "Monday, Wednesday, Friday 10am-11am" do
-
       let(:window_rules) do
         {
-          days:       "Monday:Wednesday:Friday",
-          start_time: "13:00",
-          end_time:   "14:00",
+          working_hours: {
+            mon: {"13:00" => "14:00"},
+            wed: {"13:00" => "14:00"},
+            fri: {"13:00" => "14:00"}
+          },
+          time_zone: 'UTC'
         }
       end
 
@@ -235,131 +200,122 @@ describe AdvanceAFewDays do
 
         expect(subject).to eq [date1, date2, date3, date4]
       end
-
     end
-
   end
 
   describe "find_next_occurence" do
-
     let(:window_rules) do
       {
-        days:       "Monday:Tuesday:Wednesday:Thursday",
-        start_time: "9:00",
-        end_time:   "11:00",
+        working_hours: {
+          mon: {"09:00" => "11:00"},
+          tue: {"09:00" => "11:00"},
+          wed: {"09:00" => "11:00"},
+          thu: {"09:00" => "11:00"}
+        },
+        time_zone: 'UTC'
       }
     end
 
-    let(:start_datetime) { DateTime.strptime('2016-02-20 09:00:00', '%Y-%m-%d %H:%M:%S') }
-    
-    subject { AdvanceAFewDays.find_next_occurence(window_rules, rule, start_datetime) }
+    let(:start_datetime) { Time.parse('2016-02-20 09:00:00').in_time_zone('UTC') }
+
+    subject { AdvanceAFewDays.create_days_on_earliest_send_time(window_rules, rule, start_datetime) }
 
     context "rule is start_now" do
-      let(:rule) { "start now" }
-    
+      let(:rule) { ["start now"] }
+
       context "now is within time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-22 09:05:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-22 09:05:00 +0000') }
 
         it 'should return now' do
-          expect(subject).to eq start_datetime
+          expect(subject).to eq [start_datetime]
         end
-
       end
 
       context "now is after time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-20 09:00:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-20 09:00:00 +0000') }
 
         it "should return next time in window_rules" do
           date1 = DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S')
-          expect(subject).to eq date1
+          expect(subject).to eq [date1]
         end
 
         context "window rules dates is comma separated" do
-
           let(:window_rules) do
             {
-              days:       "Wednesday:Friday",
-              start_time: "9:00",
-              end_time:   "11:00",
+              working_hours: {
+                wed: {"09:00" => "11:00"},
+                fri: {"09:00" => "11:00"}
+              },
+              time_zone: 'UTC'
             }
           end
 
           it "should return next time in window_rules" do
             date1 = DateTime.strptime('2016-02-24 09:00:00', '%Y-%m-%d %H:%M:%S')
-            expect(subject).to eq date1
+            expect(subject).to eq [date1]
           end
         end
 
         context "window rules dates are both a range and comma separated" do
-
           let(:window_rules) do
             {
-              days:       "Monday:Wednesday:Thursday",
-              start_time: "9:00",
-              end_time:   "11:00",
+              working_hours: {
+                mon: {"09:00" => "11:00"},
+                wed: {"09:00" => "11:00"},
+                thu: {"09:00" => "11:00"}
+              },
+              time_zone: 'UTC'
             }
           end
 
           it "should return next time in window_rules" do
             date1 = DateTime.strptime('2016-02-22 09:00:00', '%Y-%m-%d %H:%M:%S')
-            expect(subject).to eq date1
+            expect(subject).to eq [date1]
           end
         end
       end
-      
     end
 
-
-
     context "rule is advance 2 days" do
-      let(:rule) { "advance 2 days" }
-    
+      let(:rule) { ["advance 2 days"] }
+
       context "2 days is within time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-20 09:05:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-20 09:05:00 +0000') }
 
         it 'should return 2 days from now' do
-          expect(subject).to eq (start_datetime + 2)
+          expect(subject).to eq [(start_datetime + 2.days)]
         end
-
       end
 
       context "2 days is after time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-25 09:00:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-25 09:00:00 +0000') }
 
         it "should return next time in window_rules" do
           date1 = DateTime.strptime('2016-02-29 09:00:00', '%Y-%m-%d %H:%M:%S')
-          expect(subject).to eq date1
+          expect(subject).to eq [date1]
         end
-
       end
-      
     end
 
-
     context "rule is advance 1 week" do
-      let(:rule) { "advance 1 week" }
-    
+      let(:rule) { ["advance 1 week"] }
+
       context "1 week is within time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-22 09:05:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-22 09:05:00 +0000') }
 
         it 'should return 1 week from now' do
-          expect(subject).to eq (start_datetime + 7)
+          expect(subject).to eq [(start_datetime + 7.days)]
         end
-
       end
 
       context "1 week is after time" do
-        let(:start_datetime) { DateTime.strptime('2016-02-20 09:00:00', '%Y-%m-%d %H:%M:%S') }
+        let(:start_datetime) { Time.parse('2016-02-20 09:00:00 +0000') }
 
         it "should return next time in window_rules" do
           date1 = DateTime.strptime('2016-02-29 09:00:00', '%Y-%m-%d %H:%M:%S')
-          expect(subject).to eq date1
+          expect(subject).to eq [date1]
         end
-
       end
-      
     end
-
   end
-
 end


### PR DESCRIPTION
- use WorkingHours gem for setting window_rules and ensuring
  dates/times fall withing the window
- Tests use Time.parse instead of DateTime.strptime for a
  start_datetime
- Relaxed regex for advance_rules
- Remove extraneous code from AdvanceAFewDays module
- Update README to show in window_rules interface
